### PR TITLE
Test time-appropriate meetup text

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ group :development, :test do
   gem "rubocop"
   gem "shoulda-matchers", "~> 3.1"
   gem "simplecov", require: false
+  gem "timecop"
   gem "webmock"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,6 +202,7 @@ GEM
       sprockets (>= 3.0.0)
     thor (0.20.0)
     thread_safe (0.3.6)
+    timecop (0.9.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.4.0)
@@ -252,6 +253,7 @@ DEPENDENCIES
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
+  timecop
   tzinfo-data
   web-console (>= 3.3.0)
   webmock
@@ -263,4 +265,4 @@ RUBY VERSION
    ruby 2.4.4p296
 
 BUNDLED WITH
-   1.16.4
+   1.16.5

--- a/spec/features/events_feature_spec.rb
+++ b/spec/features/events_feature_spec.rb
@@ -1,8 +1,10 @@
 require "rails_helper"
+require "timecop"
 
 feature "Events" do
   before do
-    create(:event, name: "Katas and hang")
+    starts_at = Time.utc(2018, 9, 1, 10, 0, 0)
+    create(:event, name: "Katas and hang", start_time: starts_at, end_time: starts_at + 10.minutes)
   end
 
   it "successfully loads" do
@@ -14,5 +16,23 @@ feature "Events" do
     event = Event.find_by(name: "Katas and hang")
     visit event_path(event)
     expect(page).to have_content("Katas and hang")
+  end
+
+  it "shows 'rsvp on meetup' text if the current time is prior to the start time" do
+    test_time = Time.utc(2018, 8, 15, 12, 0, 0)
+    Timecop.freeze(test_time) do
+      event = Event.find_by(name: "Katas and hang")
+      visit event_path(event)
+      expect(page).to have_content("RSVP on Meetup")
+    end
+  end
+
+  it "shows 'view on meetup' text if the current time is after the start time" do
+    test_time = Time.utc(2018, 10, 15, 12, 0, 0)
+    Timecop.freeze(test_time) do
+      event = Event.find_by(name: "Katas and hang")
+      visit event_path(event)
+      expect(page).to have_content("View on Meetup")
+    end
   end
 end


### PR DESCRIPTION
Address issue #2:

- Add a start time to the test event that's created.
- Use timecop to warp time to before and after the start time,
  and validates that the text shown is correct in both cases.